### PR TITLE
Publish Homebrew tap and align Go module with repo name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,3 +20,5 @@ jobs:
       - run: goreleaser release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT with write access to labset/homebrew-tap (default GITHUB_TOKEN can't push cross-repo)
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -19,5 +19,5 @@ linters:
           allow:
             - $gostd
             - buf.build/go/bufplugin/check
-            - github.com/labset/go-protoc-gen-plugin/
+            - github.com/labset/go-protobuf-toolchain-template/
             - google.golang.org/protobuf

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,6 +10,7 @@ before:
 builds:
   - main: cmd/protoc-gen-echo/main.go
     id: protoc-gen-echo
+    binary: protoc-gen-echo
     env:
       - CGO_ENABLED=0
     goos:
@@ -19,6 +20,7 @@ builds:
 
   - main: cmd/echo-lint-plugin/main.go
     id: echo-lint-plugin
+    binary: echo-lint-plugin
     env:
       - CGO_ENABLED=0
     goos:
@@ -40,6 +42,22 @@ archives:
     format_overrides:
       - goos: windows
         formats: [zip]
+
+brews:
+  - name: go-protobuf-toolchain-template
+    repository:
+      owner: labset
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    homepage: "https://github.com/labset/go-protobuf-toolchain-template"
+    description: "Protobuf toolchain — protoc-gen-echo codegen plugin and echo-lint-plugin linter"
+    license: "Apache-2.0"
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    commit_msg_template: "brew: bump {{ .ProjectName }} to {{ .Tag }}"
+    # only publish the tap for real releases, never for snapshots
+    skip_upload: auto
 
 changelog:
   sort: asc

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,7 +50,7 @@ brews:
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     homepage: "https://github.com/labset/go-protobuf-toolchain-template"
-    description: "Protobuf toolchain — protoc-gen-echo codegen plugin and echo-lint-plugin linter"
+    description: "Protobuf toolchain with protoc-gen-echo codegen plugin and echo-lint-plugin linter"
     license: "Apache-2.0"
     commit_author:
       name: goreleaserbot

--- a/README.md
+++ b/README.md
@@ -6,11 +6,35 @@ Template repository for building protobuf toolchains (protoc plugins) in Go.
 
 ### usage
 
-- install it
+- install it with Homebrew
 
-````bash
-go install github.com/<username>/go-protobuf-toolchain-template/cmd/protoc-gen-echo@latest
-````
+```bash
+brew install labset/tap/go-protobuf-toolchain-template
+```
+
+This installs both `protoc-gen-echo` and `echo-lint-plugin`.
+
+- install it with `go install`
+
+```bash
+go install github.com/labset/go-protobuf-toolchain-template/cmd/protoc-gen-echo@latest
+go install github.com/labset/go-protobuf-toolchain-template/cmd/echo-lint-plugin@latest
+```
+
+- install it with mise (via the `go` backend)
+
+```bash
+mise use "go:github.com/labset/go-protobuf-toolchain-template/cmd/protoc-gen-echo@latest"
+mise use "go:github.com/labset/go-protobuf-toolchain-template/cmd/echo-lint-plugin@latest"
+```
+
+or pin them in a project's `mise.toml`:
+
+```toml
+[tools]
+"go:github.com/labset/go-protobuf-toolchain-template/cmd/protoc-gen-echo" = "latest"
+"go:github.com/labset/go-protobuf-toolchain-template/cmd/echo-lint-plugin" = "latest"
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -91,3 +91,31 @@ mise run build
 ```bash
 mise run clean
 ```
+
+### releasing
+
+Releases are cut by [GoReleaser](https://goreleaser.com/) from the `release` workflow, which
+triggers when a GitHub release is created. It builds the binaries, publishes the archives to the
+release, and pushes a Homebrew formula to the tap.
+
+**One-time setup** (required before the first release publishes the Homebrew tap):
+
+1. Create the tap repository `labset/homebrew-tap` (an empty repo is fine) — GoReleaser commits the
+   generated formula into it.
+2. Add a `HOMEBREW_TAP_GITHUB_TOKEN` repository secret — a GitHub personal access token with
+   `contents: write` permission on `labset/homebrew-tap`. The default `GITHUB_TOKEN` cannot push to
+   another repository, so this separate token is required.
+
+**Cutting a release:**
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+# then create a GitHub release for the tag (this triggers the release workflow)
+```
+
+To validate the release pipeline locally without publishing:
+
+```bash
+mise run build   # goreleaser build --clean --snapshot
+```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@
 
 Template repository for building protobuf toolchains (protoc plugins) in Go.
 
+### using this template
+
+This template uses `labset` as the GitHub org. After creating your repo, replace it with your own:
+
+```bash
+grep -rl labset . --exclude-dir=.git | xargs sed -i '' 's/labset/YOUR_ORG/g'   # sed -i on Linux
+```
+
+This covers the Go module path and imports, the Homebrew tap owner, and the install commands below.
+Run `go mod tidy` afterwards. If you also rename the repo, update `go-protobuf-toolchain-template`
+to match.
+
 ### usage
 
 - install it with Homebrew
@@ -40,7 +52,7 @@ or pin them in a project's `mise.toml`:
 
 ### requirements
 
-- [mise](https://mise.jdx.dev/) — manages `go`, `buf`, `golangci-lint` and `goreleaser` versions (see `.config/mise/conf.d`)
+- [mise](https://mise.jdx.dev/) manages `go`, `buf`, `golangci-lint` and `goreleaser` versions (see `.config/mise/conf.d`)
 
 ```bash
 mise install
@@ -100,9 +112,9 @@ release, and pushes a Homebrew formula to the tap.
 
 **One-time setup** (required before the first release publishes the Homebrew tap):
 
-1. Create the tap repository `labset/homebrew-tap` (an empty repo is fine) — GoReleaser commits the
+1. Create the tap repository `labset/homebrew-tap` (an empty repo is fine). GoReleaser commits the
    generated formula into it.
-2. Add a `HOMEBREW_TAP_GITHUB_TOKEN` repository secret — a GitHub personal access token with
+2. Add a `HOMEBREW_TAP_GITHUB_TOKEN` repository secret, a GitHub personal access token with
    `contents: write` permission on `labset/homebrew-tap`. The default `GITHUB_TOKEN` cannot push to
    another repository, so this separate token is required.
 

--- a/cmd/echo-lint-plugin/main.go
+++ b/cmd/echo-lint-plugin/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"buf.build/go/bufplugin/check"
-	"github.com/labset/go-protoc-gen-plugin/internal/rules"
+	"github.com/labset/go-protobuf-toolchain-template/internal/rules"
 )
 
 func main() {

--- a/cmd/protoc-gen-echo/main.go
+++ b/cmd/protoc-gen-echo/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/labset/go-protoc-gen-plugin/internal/codegen"
+	"github.com/labset/go-protobuf-toolchain-template/internal/codegen"
 	"google.golang.org/protobuf/compiler/protogen"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/labset/go-protoc-gen-plugin
+module github.com/labset/go-protobuf-toolchain-template
 
 go 1.25.3
 


### PR DESCRIPTION
## Summary

- Align the Go module with the repo name: `github.com/labset/go-protoc-gen-plugin` → `github.com/labset/go-protobuf-toolchain-template` (`go.mod`, both `cmd/*/main.go` imports, `.golangci.yaml` depguard)
- Add a GoReleaser `brews` block publishing one formula with both binaries (`protoc-gen-echo`, `echo-lint-plugin`) to `labset/homebrew-tap`
- Give each build an explicit `binary` name to avoid an archive filename collision (both defaulted to the project name)
- Wire `HOMEBREW_TAP_GITHUB_TOKEN` into the release workflow (the default `GITHUB_TOKEN` can't push cross-repo)
- Document brew / `go install` / mise `go`-backend install methods, the release setup, and how template users swap the org owner

## Install methods

```bash
brew install labset/tap/go-protobuf-toolchain-template
go install github.com/labset/go-protobuf-toolchain-template/cmd/protoc-gen-echo@latest
mise use "go:github.com/labset/go-protobuf-toolchain-template/cmd/echo-lint-plugin@latest"
```

## Before releases publish the tap

1. Create the `labset/homebrew-tap` repo (empty is fine)
2. Add a `HOMEBREW_TAP_GITHUB_TOKEN` secret (PAT with `contents: write` on the tap repo)

## Verification

- `go build ./...`, `go mod tidy`, `golangci-lint run` (0 issues)
- `goreleaser check` passes; `goreleaser release --snapshot` builds all archives and generates a valid formula covering macOS + Linux (Intel/ARM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
